### PR TITLE
Modified wizard dialogs to disable/enable Finish

### DIFF
--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/CompDefWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/CompDefWizard.java
@@ -192,7 +192,7 @@ public class CompDefWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 }

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/InitAssemblyWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/InitAssemblyWizard.java
@@ -169,7 +169,7 @@ public class InitAssemblyWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/IntLogicalSysWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/IntLogicalSysWizard.java
@@ -165,7 +165,7 @@ public class IntLogicalSysWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/ServicesWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/ServicesWizard.java
@@ -185,7 +185,7 @@ public class ServicesWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override

--- a/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/TypesWizard.java
+++ b/osets-eclipse-plugin/src/tech/ecoa/osets/eclipse/plugin/wizards/TypesWizard.java
@@ -189,7 +189,7 @@ public class TypesWizard extends Wizard implements INewWizard {
 
 	@Override
 	public boolean canFinish() {
-		return true;
+		return page.isPageComplete();
 	}
 
 	@Override


### PR DESCRIPTION
The wizard dialgs for types, services, logical system, initial assembly and component definition had the 'Finish' button enabled by default. This allowed submission of the forms unlike the other multi-page wizard dialogs. Modification of the canFinish methods to check whether the page was complete resolves this issue.